### PR TITLE
feat: add Morse playback adapter with freqStr fix and side-effect gating (my-xki)

### DIFF
--- a/cw_snippets.js
+++ b/cw_snippets.js
@@ -31,44 +31,106 @@ async function sendMorseMessage(freqStr, text) {
   const upper = text.toUpperCase();
   const unit = UNIT_MS;
 
-  for (let ci = 0; ci < upper.length; ci++) {
-    const ch = upper[ci];
-
-    if (ch === " ") {
-      // Word gap: use separately-configurable WORD_GAP_MS
-      await sleep(WORD_GAP_MS);
-      continue;
+  // Apply frequency override when provided
+  var prevFreq = null;
+  if (freqStr && note_node) {
+    var freq = parseFloat(freqStr);
+    if (!isNaN(freq) && freq > 0) {
+      prevFreq = note_node.frequency.value;
+      note_node.frequency.value = freq;
     }
+  }
 
-    const pattern = MORSE_TABLE[ch];
-    if (!pattern) {
-      // Unknown character, skip
-      continue;
-    }
+  try {
+    for (let ci = 0; ci < upper.length; ci++) {
+      const ch = upper[ci];
 
-    for (let si = 0; si < pattern.length; si++) {
-      const sym = pattern[si];
-      const durUnits = sym === "." ? 1 : 3;
+      if (ch === " ") {
+        // Word gap: use separately-configurable WORD_GAP_MS
+        await sleep(WORD_GAP_MS);
+        continue;
+      }
 
-      const msgDown = `${freqStr} Key down`;
-      const msgUp = `${freqStr} key up`;
+      const pattern = MORSE_TABLE[ch];
+      if (!pattern) {
+        // Unknown character, skip
+        continue;
+      }
 
-      keyPress();
-      await sleep(durUnits * unit);
-      keyRelease();
+      for (let si = 0; si < pattern.length; si++) {
+        const sym = pattern[si];
+        const durUnits = sym === "." ? 1 : 3;
 
-      // Intra-character gap (between elements) = 1 unit, except after last element
-      if (si < pattern.length - 1) {
-        await sleep(unit);
+        playSidetone();
+        await sleep(durUnits * unit);
+        stopSidetone();
+
+        // Intra-character gap (between elements) = 1 unit, except after last element
+        if (si < pattern.length - 1) {
+          await sleep(unit);
+        }
+      }
+
+      // Inter-character gap (between letters) = 3 units,
+      // but if the next char is a space, the 7-unit word gap
+      // will be applied when we hit the space, so we do nothing here.
+      const nextChar = upper[ci + 1];
+      if (nextChar && nextChar !== " ") {
+        await sleep(unit * 3);
       }
     }
-
-    // Inter-character gap (between letters) = 3 units,
-    // but if the next char is a space, the 7-unit word gap
-    // will be applied when we hit the space, so we do nothing here.
-    const nextChar = upper[ci + 1];
-    if (nextChar && nextChar !== " ") {
-      await sleep(unit * 3);
+  } finally {
+    // Restore previous frequency
+    if (prevFreq !== null && note_node) {
+      note_node.frequency.value = prevFreq;
     }
+  }
+}
+
+// === Morse Playback Adapter ================================================
+// Wraps sendMorseMessage for game playback, gating keyPress/keyRelease side
+// effects via morsePlaybackActive.
+
+/**
+ * Play an array of characters as Morse with proper inter-character spacing.
+ * Sets morsePlaybackActive to prevent histogram/cwmsg corruption.
+ *
+ * @param {string[]} sequence - Array of uppercase characters to play.
+ * @param {number} [wpm] - Optional WPM override (temporarily changes UNIT_MS).
+ * @returns {Promise<void>}
+ */
+async function playSequenceMorse(sequence, wpm) {
+  await ensureAudioReady();
+  morsePlaybackActive = true;
+  var savedUnit = UNIT_MS;
+  if (wpm && wpm > 0) {
+    UNIT_MS = Math.round(1200 / wpm);
+  }
+  try {
+    await sendMorseMessage(null, sequence.join(""));
+  } finally {
+    UNIT_MS = savedUnit;
+    morsePlaybackActive = false;
+    stopSidetone();
+  }
+}
+
+/**
+ * Play a single character as Morse, with optional frequency override.
+ * Sets morsePlaybackActive to prevent histogram/cwmsg corruption.
+ *
+ * @param {string} char - Single character to play.
+ * @param {number|string} [freq] - Optional frequency in Hz (overrides default).
+ * @returns {Promise<void>}
+ */
+async function playCharMorse(char, freq) {
+  await ensureAudioReady();
+  morsePlaybackActive = true;
+  try {
+    var freqStr = freq ? String(freq) : null;
+    await sendMorseMessage(freqStr, char);
+  } finally {
+    morsePlaybackActive = false;
+    stopSidetone();
   }
 }

--- a/pt-cwsimon.js
+++ b/pt-cwsimon.js
@@ -404,6 +404,7 @@ function logMessage(message) {
 console.log = logMessage;
 
 function keyPress() {
+  if (morsePlaybackActive) return;
   if (keydown === 0) {
     const now = performance.now();
     if (utime !== 0) {
@@ -424,6 +425,7 @@ function keyPress() {
 }
 
 function keyRelease() {
+  if (morsePlaybackActive) return;
   // Ignore stray releases
   if (keydown === 0) return;
 


### PR DESCRIPTION
## Summary
- Fix `sendMorseMessage` to actually use the `freqStr` parameter (save/restore oscillator frequency)
- Replace `keyPress()`/`keyRelease()` with `playSidetone()`/`stopSidetone()` in `sendMorseMessage` to avoid corrupting histograms and cwmsg during game playback
- Add `morsePlaybackActive` guard to `keyPress`/`keyRelease` as double protection
- Add `playSequenceMorse(sequence, wpm)` and `playCharMorse(char, freq)` adapter functions for game playback

## Test plan
- [ ] Verify Morse playback uses correct frequency when `freqStr` is provided
- [ ] Verify game playback does not corrupt histogram or cwmsg state
- [ ] Verify `playSequenceMorse` plays full sequences with proper timing
- [ ] Verify `playCharMorse` works with optional frequency override

🤖 Generated with [Claude Code](https://claude.com/claude-code)