### PR TITLE
feat: add per-letter overlay that fades when each letter's audio ends (my-5v3)

### DIFF
--- a/pt-cwsimon.html
+++ b/pt-cwsimon.html
@@ -173,6 +173,29 @@
         font-size: 1.1rem;
         font-variant-numeric: tabular-nums;
       }
+
+      #morseOverlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 30vw;
+        font-weight: bold;
+        color: #fff;
+        pointer-events: none;
+        z-index: 9998;
+        opacity: 0;
+        transition: opacity 0.4s ease-out;
+      }
+
+      #morseOverlay.visible {
+        opacity: 1;
+        transition: none;
+      }
     </style>
   </head>
   <body>
@@ -197,6 +220,8 @@
       <div id="2">2</div>
       <div id="3">3</div>
     </div>
+
+    <div id="morseOverlay"></div>
 
     <div id="console" class="console"></div>
 

--- a/pt-cwsimon.js
+++ b/pt-cwsimon.js
@@ -585,12 +585,28 @@ document.addEventListener("DOMContentLoaded", () => {
   refreshSpeedDisplay();
 });
 
+// === Letter Overlay ========================================================
+
+function showLetterOverlay(letter) {
+  var el = document.getElementById("morseOverlay");
+  if (!el) return;
+  el.textContent = letter;
+  el.classList.add("visible");
+}
+
+function fadeLetterOverlay() {
+  var el = document.getElementById("morseOverlay");
+  if (!el) return;
+  el.classList.remove("visible");
+}
+
 // === Simon Game Orchestration =============================================
 
 /**
  * Play a sequence of characters as Morse sidetone.
  * Uses playSidetone()/stopSidetone() directly to avoid side effects
  * from keyPress()/keyRelease() (histograms, keyer hooks, cwmsg).
+ * Shows a per-letter overlay that fades when each letter's audio ends.
  *
  * @param {string[]} sequence - Array of uppercase characters to play.
  */
@@ -599,6 +615,8 @@ async function playMorseSequence(sequence) {
   for (var i = 0; i < sequence.length; i++) {
     var pattern = SimonGame.encodeMorse(sequence[i]);
     if (!pattern) continue;
+
+    showLetterOverlay(sequence[i]);
 
     for (var j = 0; j < pattern.length; j++) {
       var durUnits = pattern[j] === "." ? 1 : 3;
@@ -610,6 +628,9 @@ async function playMorseSequence(sequence) {
         await sleep(unit);
       }
     }
+
+    fadeLetterOverlay();
+
     // Inter-character gap (between letters)
     if (i < sequence.length - 1) {
       await sleep(unit * 3);


### PR DESCRIPTION
## Summary
- Add full-screen `#morseOverlay` div with CSS fade transition (opacity 0.4s ease-out)
- `pointer-events: none` to avoid interfering with iambic keyer touch areas
- `showLetterOverlay` / `fadeLetterOverlay` functions called from `playMorseSequence()` per-character loop
- Overlay appears instantly when letter audio starts, fades when audio ends

## Test plan
- [ ] Verify letter overlay appears during Morse sequence playback
- [ ] Verify overlay fades after each letter's audio completes
- [ ] Verify keyer touch areas remain functional with overlay present
- [ ] Verify overlay works on mobile screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)